### PR TITLE
Itération 3 : gestion des autorisations

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -128,10 +128,10 @@ Pour afficher toutes les commandes disponibles:
 
   ./cli/client.sh --help
 
-## Authentification
+## Authentification
 
 Une documentation qui explique le mécanisme d'authentification est disponible link:doc/authentification.adoc[ici].
 
-## Authorization
+## Authorization
 
 Une documentation qui explique le mécanisme de contrôle d'accès est disponible link:doc/autorisation.adoc[ici].

--- a/README.adoc
+++ b/README.adoc
@@ -132,3 +132,6 @@ Pour afficher toutes les commandes disponibles:
 
 Une documentation qui explique le mécanisme d'authentification est disponible link:doc/authentification.adoc[ici].
 
+## Authorization
+
+Une documentation qui explique le mécanisme de contrôle d'accès est disponible link:doc/autorisation.adoc[ici].

--- a/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/cas/DauphineCas.java
+++ b/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/cas/DauphineCas.java
@@ -1,5 +1,7 @@
 package io.github.oliviercailloux.y2018.opendata.cas;
 
+import java.util.HashSet;
+
 /**
  * A proxy to the Dauphine CAS
  */
@@ -27,4 +29,5 @@ public interface DauphineCas {
      * @return the list of roles
      * @throws DauphineCasException if the list of roles can't be retrieved
      */
+    HashSet<String> getRoles(String username) throws DauphineCasException;
 }

--- a/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/cas/DauphineCas.java
+++ b/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/cas/DauphineCas.java
@@ -1,7 +1,5 @@
 package io.github.oliviercailloux.y2018.opendata.cas;
 
-import java.util.HashSet;
-
 /**
  * A proxy to the Dauphine CAS
  */
@@ -29,5 +27,5 @@ public interface DauphineCas {
      * @return the list of roles
      * @throws DauphineCasException if the list of roles can't be retrieved
      */
-    HashSet<String> getRoles(String username) throws DauphineCasException;
+    String[] getRoles(String username) throws DauphineCasException;
 }

--- a/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/cas/DauphineCas.java
+++ b/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/cas/DauphineCas.java
@@ -1,5 +1,7 @@
 package io.github.oliviercailloux.y2018.opendata.cas;
 
+import com.google.common.collect.ImmutableList;
+
 /**
  * A proxy to the Dauphine CAS
  */
@@ -27,5 +29,5 @@ public interface DauphineCas {
      * @return the list of roles
      * @throws DauphineCasException if the list of roles can't be retrieved
      */
-    String[] getRoles(String username) throws DauphineCasException;
+    ImmutableList<String> getRoles(String username) throws DauphineCasException;
 }

--- a/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/cas/FakeDauphineCas.java
+++ b/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/cas/FakeDauphineCas.java
@@ -37,9 +37,9 @@ public class FakeDauphineCas implements DauphineCas {
     }
     
     @Override
-    public HashSet<String> getRoles(String username) throws DauphineCasException {
+    public String[] getRoles(String username) throws DauphineCasException {
         return userTable.getUser(username)
-                .map(u -> new HashSet<>(Arrays.asList(u.getRoles())))
+                .map(FakeUserRecord::getRoles)
                 .orElseThrow(() -> new DauphineCasException("Unknown user " + username));
     }
 }

--- a/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/cas/FakeDauphineCas.java
+++ b/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/cas/FakeDauphineCas.java
@@ -1,5 +1,6 @@
 package io.github.oliviercailloux.y2018.opendata.cas;
 
+import com.google.common.collect.ImmutableList;
 import io.github.oliviercailloux.y2018.opendata.cas.FakeUserTable.FakeUserRecord;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -37,7 +38,7 @@ public class FakeDauphineCas implements DauphineCas {
     }
     
     @Override
-    public String[] getRoles(String username) throws DauphineCasException {
+    public ImmutableList<String> getRoles(String username) throws DauphineCasException {
         return userTable.getUser(username)
                 .map(FakeUserRecord::getRoles)
                 .orElseThrow(() -> new DauphineCasException("Unknown user " + username));
@@ -55,7 +56,7 @@ class FakeUserTable {
     static class FakeUserRecord {
         private String username;
         private String password;
-        private String[] roles;
+        private ImmutableList<String> roles;
     }
     
     private Map<String, FakeUserRecord> table;
@@ -71,7 +72,7 @@ class FakeUserTable {
     }
     
     private void addUser(String username, String password, String[] roles) {
-        table.put(username, new FakeUserRecord(username, password, roles));
+        table.put(username, new FakeUserRecord(username, password, ImmutableList.copyOf(roles)));
     }
 }
 

--- a/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/cas/FakeDauphineCas.java
+++ b/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/cas/FakeDauphineCas.java
@@ -1,7 +1,13 @@
 package io.github.oliviercailloux.y2018.opendata.cas;
 
+import io.github.oliviercailloux.y2018.opendata.cas.FakeUserTable.FakeUserRecord;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
+import java.util.*;
 
 /**
  * This class is a fake proxy to the Dauphine CAS.
@@ -10,13 +16,93 @@ import javax.enterprise.inject.Default;
 @ApplicationScoped
 public class FakeDauphineCas implements DauphineCas {
     
+    private FakeTokenIssuer tokenIssuer = new FakeTokenIssuer();
+    private FakeUserTable userTable = new FakeUserTable();
+    
     @Override
     public String authenticate(Credentials credentials) throws DauphineCasException {
-        return "fake-token";
+        FakeUserRecord user = userTable.getUser(credentials.getUsername())
+                .orElseThrow(() -> new DauphineCasException("Unknown user " + credentials.getUsername()));
+
+        if (!user.getPassword().equals(credentials.getPassword())) {
+            throw new DauphineCasException("Invalid credentials");
+        }
+
+        return tokenIssuer.issueToken(credentials.getUsername());
     }
     
     @Override
     public String validateToken(String token) throws DauphineCasException {
-        return "toto";
+        return tokenIssuer.validateToken(token).orElseThrow(() -> new DauphineCasException("Invalid token " + token));
+    }
+    
+    @Override
+    public HashSet<String> getRoles(String username) throws DauphineCasException {
+        return userTable.getUser(username)
+                .map(u -> new HashSet<>(Arrays.asList(u.getRoles())))
+                .orElseThrow(() -> new DauphineCasException("Unknown user " + username));
+    }
+}
+
+/**
+ * This is a fake user table containing (login, password, roles) tuples.
+ */
+class FakeUserTable {
+    
+    @AllArgsConstructor
+    @Getter
+    @Setter
+    static class FakeUserRecord {
+        private String username;
+        private String password;
+        private String[] roles;
+    }
+    
+    private Map<String, FakeUserRecord> table;
+    {
+        table = new HashMap<>();
+        addUser("loic", "123", new String[]{Roles.STUDENT});
+        addUser("marcel", "456", new String[]{Roles.TEACHER});
+        addUser("sylvie", "789", new String[]{Roles.ADMIN, Roles.TEACHER});
+    }
+    
+    Optional<FakeUserRecord> getUser(String username) {
+        return Optional.ofNullable(table.get(username));
+    }
+    
+    private void addUser(String username, String password, String[] roles) {
+        table.put(username, new FakeUserRecord(username, password, roles));
+    }
+}
+
+/**
+ * This is a Fake Service that issue tokens for the FakeDauphineCas proxy.
+ */
+class FakeTokenIssuer {
+    
+    private Map<String, String> tokenCache = new HashMap<>();
+    
+    private String generateRandomToken() {
+        return UUID.randomUUID().toString();
+    }
+    
+    /**
+     * Generate a token (infinite validity) for a given user
+     * @param username a dauphine login
+     * @return the issued token
+     */
+    String issueToken(String username) {
+        final String token = generateRandomToken();
+        tokenCache.put(token, username);
+        return token;
+    }
+    
+    /**
+     * Validate a token
+     * @param token the token
+     * @return the username or nothing if the token is invalid
+     */
+    Optional<String> validateToken(String token) {
+        return Optional.ofNullable(tokenCache.get(token));
     }
 }

--- a/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/cas/Roles.java
+++ b/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/cas/Roles.java
@@ -7,7 +7,7 @@ package io.github.oliviercailloux.y2018.opendata.cas;
  * and define some constants for known roles.
  */
 public class Roles {
-    public static String ADMIN = "admin";
-    public static String TEACHER = "teacher";
-    public static String STUDENT = "student";
+    public static final String ADMIN = "admin";
+    public static final String TEACHER = "teacher";
+    public static final String STUDENT = "student";
 }

--- a/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/cas/Roles.java
+++ b/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/cas/Roles.java
@@ -1,0 +1,13 @@
+package io.github.oliviercailloux.y2018.opendata.cas;
+
+/**
+ * This class contains static constants for known Dauphine CAS roles.
+ *
+ * Roles could be modeled as an Enum type, but it would not fit with their dynamic nature, so we rather use Strings
+ * and define some constants for known roles.
+ */
+public class Roles {
+    public static String ADMIN = "admin";
+    public static String TEACHER = "teacher";
+    public static String STUDENT = "student";
+}

--- a/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/provider/AuthenticationFilter.java
+++ b/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/provider/AuthenticationFilter.java
@@ -13,7 +13,6 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.ext.Provider;
-import java.io.IOException;
 import java.security.Principal;
 
 /**

--- a/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/provider/AuthenticationFilter.java
+++ b/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/provider/AuthenticationFilter.java
@@ -14,6 +14,9 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.ext.Provider;
 import java.security.Principal;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * This filter is called before the request is processed and is responsible of authentication based on the bearer token
@@ -56,10 +59,12 @@ public class AuthenticationFilter implements ContainerRequestFilter {
         }
     }
     
-    private void attachUsernameToContext(String username, ContainerRequestContext requestContext) {
+    private void attachUsernameToContext(String username, ContainerRequestContext requestContext) throws DauphineCasException {
         final SecurityContext currentSecurityContext = requestContext.getSecurityContext();
         requestContext.setSecurityContext(new SecurityContext() {
         
+            private Set<String> roles = new HashSet<>(Arrays.asList(dauphineCas.getRoles(username)));
+            
             @Override
             public Principal getUserPrincipal() {
                 return () -> username;
@@ -67,8 +72,7 @@ public class AuthenticationFilter implements ContainerRequestFilter {
         
             @Override
             public boolean isUserInRole(String role) {
-                // TODO: Role based access
-                return true;
+                return roles.contains(role);
             }
         
             @Override

--- a/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/provider/AuthenticationFilter.java
+++ b/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/provider/AuthenticationFilter.java
@@ -1,5 +1,6 @@
 package io.github.oliviercailloux.y2018.opendata.provider;
 
+import com.google.common.collect.ImmutableList;
 import io.github.oliviercailloux.y2018.opendata.annotation.Secured;
 import io.github.oliviercailloux.y2018.opendata.cas.DauphineCas;
 import io.github.oliviercailloux.y2018.opendata.cas.DauphineCasException;
@@ -63,7 +64,7 @@ public class AuthenticationFilter implements ContainerRequestFilter {
         final SecurityContext currentSecurityContext = requestContext.getSecurityContext();
         requestContext.setSecurityContext(new SecurityContext() {
         
-            private Set<String> roles = new HashSet<>(Arrays.asList(dauphineCas.getRoles(username)));
+            private ImmutableList<String> roles = dauphineCas.getRoles(username);
             
             @Override
             public Principal getUserPrincipal() {

--- a/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/provider/AuthorizationFilter.java
+++ b/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/provider/AuthorizationFilter.java
@@ -1,0 +1,113 @@
+package io.github.oliviercailloux.y2018.opendata.provider;
+
+import javax.annotation.Priority;
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+import java.lang.reflect.Method;
+
+/**
+ * This filter perform authorization using standard java annotations @DenyAll, @PermitAll and @RolesAllowed.
+ * Theses annotation can either stand on resource classes or methods.
+ * There is some precedences rules implemented in the logic of the filter method, read the comments for more understanding.
+ *
+ * The annotation @PermitAll is the default.
+ * You can mix authorization and @Secured (for authentication)
+ * The annotation @RolesAllowed should always be set with @Secured, otherwise it rejects all requests.
+ *
+ * the Priority annotation below is required for this filter to be ran after the AuthenticationFilter
+ */
+@Provider
+@Priority(Priorities.AUTHORIZATION)
+public class AuthorizationFilter implements ContainerRequestFilter {
+    
+    @Context
+    private ResourceInfo resourceInfo;
+    
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        
+        Method method = resourceInfo.getResourceMethod();
+        
+        // @DenyAll on the method takes precedence over @RolesAllowed and @PermitAll
+        if (method.isAnnotationPresent(DenyAll.class)) {
+            refuseRequest(requestContext);
+            return ;
+        }
+        
+        // @RolesAllowed on the method takes precedence over @PermitAll
+        RolesAllowed rolesAllowed = method.getAnnotation(RolesAllowed.class);
+        if (rolesAllowed != null) {
+            performAuthorization(rolesAllowed.value(), requestContext);
+            return;
+        }
+        
+        // @PermitAll on the method takes precedence over @RolesAllowed on the class
+        if (method.isAnnotationPresent(PermitAll.class)) {
+            // Do nothing
+            return;
+        }
+        
+        // @DenyAll can't be attached to classes
+        
+        // @RolesAllowed on the class takes precedence over @PermitAll on the class
+        rolesAllowed =
+                resourceInfo.getResourceClass().getAnnotation(RolesAllowed.class);
+        if (rolesAllowed != null) {
+            performAuthorization(rolesAllowed.value(), requestContext);
+        }
+        
+        // @PermitAll on the class
+        if (resourceInfo.getResourceClass().isAnnotationPresent(PermitAll.class)) {
+            // Do nothing
+            return;
+        }
+    }
+    
+    /**
+     * Perform authorization based on roles.
+     *
+     * @param rolesAllowed
+     * @param requestContext
+     */
+    private void performAuthorization(String[] rolesAllowed,
+                                      ContainerRequestContext requestContext) {
+        
+        if (rolesAllowed.length > 0 && !isAuthenticated(requestContext)) {
+            refuseRequest(requestContext);
+        }
+        
+        for (final String role : rolesAllowed) {
+            if (requestContext.getSecurityContext().isUserInRole(role)) {
+                return;
+            }
+        }
+        
+        refuseRequest(requestContext);
+    }
+    
+    /**
+     * Check if the user is authenticated.
+     *
+     * @param requestContext
+     * @return
+     */
+    private boolean isAuthenticated(final ContainerRequestContext requestContext) {
+        return requestContext.getSecurityContext().getUserPrincipal() != null;
+    }
+    
+    /**
+     * Refuse the request.
+     */
+    private void refuseRequest(ContainerRequestContext requestContext) {
+        requestContext.abortWith(
+                Response.status(Response.Status.FORBIDDEN).build());
+    }
+}

--- a/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/provider/AuthorizationFilter.java
+++ b/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/provider/AuthorizationFilter.java
@@ -65,11 +65,13 @@ public class AuthorizationFilter implements ContainerRequestFilter {
             return ;
         }
         
-        // @PermitAll on the class
+        // @PermitAll on the class... this is a non-op since PermitAll is the default
         if (resourceInfo.getResourceClass().isAnnotationPresent(PermitAll.class)) {
-            // Do nothing
+            // Accept the query
             return;
         }
+        
+        // Default is PermitAll.. Accept
     }
     
     /**

--- a/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/provider/AuthorizationFilter.java
+++ b/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/provider/AuthorizationFilter.java
@@ -62,6 +62,7 @@ public class AuthorizationFilter implements ContainerRequestFilter {
                 resourceInfo.getResourceClass().getAnnotation(RolesAllowed.class);
         if (rolesAllowed != null) {
             performAuthorization(rolesAllowed.value(), requestContext);
+            return ;
         }
         
         // @PermitAll on the class

--- a/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/resource/AbstractResource.java
+++ b/dauphine-open-data/src/main/java/io/github/oliviercailloux/y2018/opendata/resource/AbstractResource.java
@@ -4,6 +4,8 @@ import java.net.URI;
 import java.util.Optional;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.transaction.Transactional;
 import javax.ws.rs.Consumes;
@@ -19,6 +21,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 import io.github.oliviercailloux.y2018.opendata.annotation.Secured;
+import io.github.oliviercailloux.y2018.opendata.cas.Roles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,6 +112,7 @@ public abstract class AbstractResource<E extends Entity, D extends Dao<E>> {
 	 */
 	@GET
 	@Secured
+	@PermitAll
 	public Response get() {
 		LOGGER.info("[{}] - finding all entities ..", resourceName);
 		return Response.ok(dao.findAll()).build();
@@ -125,6 +129,7 @@ public abstract class AbstractResource<E extends Entity, D extends Dao<E>> {
 	@GET
 	@Path("{id}")
 	@Secured
+	@PermitAll
 	public Response get(@PathParam("id") Long id) {
 		LOGGER.info("[{}] - finding entity with id [{}] ..", resourceName, id);
 		if (id == null) {
@@ -149,6 +154,7 @@ public abstract class AbstractResource<E extends Entity, D extends Dao<E>> {
 	 */
 	@POST
 	@Secured
+	@RolesAllowed({Roles.ADMIN})
 	public Response post(E entity) {
 		LOGGER.info("[{}] - creating entity [{}] ..", resourceName, entity);
 		try {
@@ -191,6 +197,7 @@ public abstract class AbstractResource<E extends Entity, D extends Dao<E>> {
 	 */
 	@PUT
 	@Secured
+	@RolesAllowed({Roles.ADMIN, Roles.TEACHER})
 	public Response put(E entity) {
 		LOGGER.info("[{}] - putting entity with id [{}] ..", resourceName, entity);
 		
@@ -215,6 +222,7 @@ public abstract class AbstractResource<E extends Entity, D extends Dao<E>> {
 	@DELETE
 	@Path("{id}")
 	@Secured
+	@RolesAllowed({Roles.ADMIN})
 	public Response delete(@PathParam("id") Long id) {
 		LOGGER.info("[{}] - removing entity with id [{}] ..", resourceName, id);
 		try {

--- a/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/cas/AuthorizationResource.java
+++ b/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/cas/AuthorizationResource.java
@@ -1,0 +1,88 @@
+package io.github.oliviercailloux.y2018.opendata.cas;
+
+import io.github.oliviercailloux.y2018.opendata.annotation.Secured;
+
+import javax.annotation.security.DenyAll;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+/**
+ * This is a JAX-RS resource for testing different combination of authentication and authorization annotations
+ */
+@Path("/test/authorization")
+public class AuthorizationResource {
+    
+    @GET
+    @Path("permitAll")
+    @PermitAll
+    public Response permitAll() {
+        return Response.ok().build();
+    }
+    
+    @GET
+    @Path("permitAllSecured")
+    @PermitAll
+    @Secured
+    public Response permitAllSecured() {
+        return Response.ok().build();
+    }
+    
+    @GET
+    @Path("denyAll")
+    @DenyAll
+    public Response denyAll() {
+        return Response.ok().build();
+    }
+    
+    @GET
+    @Path("denyAllSecured")
+    @DenyAll
+    @Secured
+    public Response denyAllSecured() {
+        return Response.ok().build();
+    }
+    
+    @GET
+    @Path("rolesAllowedAdmin")
+    @RolesAllowed({Roles.ADMIN})
+    public Response rolesAllowedAdmin(){
+        return Response.ok().build();
+    }
+    
+    @GET
+    @Path("rolesAllowedAdminSecured")
+    @Secured
+    @RolesAllowed({Roles.ADMIN})
+    public Response rolesAllowedAdminSecured(){
+        return Response.ok().build();
+    }
+    
+    @GET
+    @Path("rolesAllowedAdminAndStudentSecured")
+    @Secured
+    @RolesAllowed({Roles.ADMIN, Roles.STUDENT})
+    public Response rolesAllowedAdminAndStudentSecured(){
+        return Response.ok().build();
+    }
+    
+    @GET
+    @Path("denyAllOverRoleAllowedAdminSecured")
+    @Secured
+    @DenyAll
+    @RolesAllowed({Roles.ADMIN})
+    public Response denyAllOverRoleAllowedAdminSecured(){
+        return Response.ok().build();
+    }
+    
+    @GET
+    @Path("roleAllowedAdminOverPermitAllSecured")
+    @Secured
+    @PermitAll
+    @RolesAllowed({Roles.ADMIN})
+    public Response roleAllowedAdminOverPermitAllSecured(){
+        return Response.ok().build();
+    }
+}

--- a/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/cas/FakeDauphineCasTest.java
+++ b/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/cas/FakeDauphineCasTest.java
@@ -46,7 +46,7 @@ public class FakeDauphineCasTest {
     
     @Test
     public void testRoles() throws DauphineCasException {
-        assertArrayEquals(new String[]{Roles.STUDENT}, cas.getRoles("loic"));
+        assertArrayEquals(new String[]{Roles.STUDENT}, cas.getRoles("loic").toArray());
     }
     
     @Test(expected = DauphineCasException.class)

--- a/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/cas/FakeDauphineCasTest.java
+++ b/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/cas/FakeDauphineCasTest.java
@@ -14,39 +14,39 @@ import static org.mockito.BDDMockito.then;
 
 /**
  * This unit test class ensure the FakeDauphineCas is working as expected.
- *
+ * <p>
  * FakeDauphineCas is populated with a fake user list. We expect the user "loic" exists and has password "123" and role
  * "student"
  */
 public class FakeDauphineCasTest {
-	
-	private FakeDauphineCas cas;
-	
-	@Before
-	public void setup() {
-		cas = new FakeDauphineCas();
-	}
-	
-	@Test
-	public void testSequence() throws DauphineCasException {
-		String token = cas.authenticate(new Credentials("loic", "123"));
-		assertEquals("loic", cas.validateToken(token));
-		// should not throw any exception
-	}
-	
+    
+    private FakeDauphineCas cas;
+    
+    @Before
+    public void setup() {
+        cas = new FakeDauphineCas();
+    }
+    
+    @Test
+    public void testSequence() throws DauphineCasException {
+        String token = cas.authenticate(new Credentials("loic", "123"));
+        assertEquals("loic", cas.validateToken(token));
+        // should not throw any exception
+    }
+    
     @Test(expected = DauphineCasException.class)
-	public void testWrongCredentials() throws DauphineCasException {
-		cas.authenticate(new Credentials("loic", "aaaaaaa"));
-	}
+    public void testWrongCredentials() throws DauphineCasException {
+        cas.authenticate(new Credentials("loic", "aaaaaaa"));
+    }
     
     @Test(expected = DauphineCasException.class)
     public void testWrongToken() throws DauphineCasException {
-	    cas.validateToken("bbbbbb");
+        cas.validateToken("bbbbbb");
     }
     
     @Test
     public void testRoles() throws DauphineCasException {
-        assertArrayEquals(new String[] {Roles.STUDENT}, cas.getRoles("loic"));
+        assertArrayEquals(new String[]{Roles.STUDENT}, cas.getRoles("loic"));
     }
     
     @Test(expected = DauphineCasException.class)

--- a/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/cas/FakeDauphineCasTest.java
+++ b/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/cas/FakeDauphineCasTest.java
@@ -1,0 +1,55 @@
+package io.github.oliviercailloux.y2018.opendata.cas;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.management.relation.Role;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.BDDMockito.then;
+
+/**
+ * This unit test class ensure the FakeDauphineCas is working as expected.
+ *
+ * FakeDauphineCas is populated with a fake user list. We expect the user "loic" exists and has password "123" and role
+ * "student"
+ */
+public class FakeDauphineCasTest {
+	
+	private FakeDauphineCas cas;
+	
+	@Before
+	public void setup() {
+		cas = new FakeDauphineCas();
+	}
+	
+	@Test
+	public void testSequence() throws DauphineCasException {
+		String token = cas.authenticate(new Credentials("loic", "123"));
+		assertEquals("loic", cas.validateToken(token));
+		// should not throw any exception
+	}
+	
+    @Test(expected = DauphineCasException.class)
+	public void testWrongCredentials() throws DauphineCasException {
+		cas.authenticate(new Credentials("loic", "aaaaaaa"));
+	}
+    
+    @Test(expected = DauphineCasException.class)
+    public void testWrongToken() throws DauphineCasException {
+	    cas.validateToken("bbbbbb");
+    }
+    
+    @Test
+    public void testRoles() throws DauphineCasException {
+        assertEquals(new HashSet<>(Collections.singletonList(Roles.STUDENT)), cas.getRoles("loic"));
+    }
+    
+    @Test(expected = DauphineCasException.class)
+    public void testRolesWrongUser() throws DauphineCasException {
+        cas.getRoles("bababa");
+    }
+}

--- a/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/cas/FakeDauphineCasTest.java
+++ b/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/cas/FakeDauphineCasTest.java
@@ -8,6 +8,7 @@ import javax.management.relation.Role;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.BDDMockito.then;
 
@@ -45,7 +46,7 @@ public class FakeDauphineCasTest {
     
     @Test
     public void testRoles() throws DauphineCasException {
-        assertEquals(new HashSet<>(Collections.singletonList(Roles.STUDENT)), cas.getRoles("loic"));
+        assertArrayEquals(new String[] {Roles.STUDENT}, cas.getRoles("loic"));
     }
     
     @Test(expected = DauphineCasException.class)

--- a/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/cas/TestDauphineCas.java
+++ b/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/cas/TestDauphineCas.java
@@ -18,6 +18,10 @@ public class TestDauphineCas implements DauphineCas {
     public final static String STUDENT_PASSWORD = "user-password";
     public final static String STUDENT_TOKEN = "user-token";
     
+    public final static String TEACHER_USERNAME = "teacher";
+    public final static String TEACHER_PASSWORD = "teacher-password";
+    public final static String TEACHER_TOKEN = "teacher-token";
+    
     
     @Override
     public String authenticate(Credentials credentials) throws DauphineCasException {
@@ -26,6 +30,9 @@ public class TestDauphineCas implements DauphineCas {
         }
         if (credentials.getUsername().equals(STUDENT_USERNAME) && credentials.getPassword().equals(STUDENT_PASSWORD)) {
             return STUDENT_TOKEN;
+        }
+        if (credentials.getUsername().equals(TEACHER_USERNAME) && credentials.getPassword().equals(TEACHER_PASSWORD)) {
+            return TEACHER_TOKEN;
         }
         throw new DauphineCasException();
     }
@@ -38,6 +45,9 @@ public class TestDauphineCas implements DauphineCas {
         if (token.equals(STUDENT_TOKEN)) {
             return STUDENT_USERNAME;
         }
+        if (token.equals(TEACHER_TOKEN)) {
+            return TEACHER_USERNAME;
+        }
         throw new DauphineCasException();
     }
     
@@ -48,6 +58,9 @@ public class TestDauphineCas implements DauphineCas {
         }
         if (username.equals(STUDENT_USERNAME)) {
             return new String[] {Roles.STUDENT};
+        }
+        if (username.equals(TEACHER_USERNAME)) {
+            return new String[] {Roles.TEACHER};
         }
         throw new DauphineCasException();
     }

--- a/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/cas/TestDauphineCas.java
+++ b/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/cas/TestDauphineCas.java
@@ -1,5 +1,7 @@
 package io.github.oliviercailloux.y2018.opendata.cas;
 
+import com.google.common.collect.ImmutableList;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
 
@@ -52,15 +54,15 @@ public class TestDauphineCas implements DauphineCas {
     }
     
     @Override
-    public String[] getRoles(String username) throws DauphineCasException {
+    public ImmutableList<String> getRoles(String username) throws DauphineCasException {
         if (username.equals(ADMIN_USERNAME)) {
-            return new String[] {Roles.ADMIN};
+            return ImmutableList.of(Roles.ADMIN);
         }
         if (username.equals(STUDENT_USERNAME)) {
-            return new String[] {Roles.STUDENT};
+            return ImmutableList.of(Roles.STUDENT);
         }
         if (username.equals(TEACHER_USERNAME)) {
-            return new String[] {Roles.TEACHER};
+            return ImmutableList.of(Roles.TEACHER);
         }
         throw new DauphineCasException();
     }

--- a/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/cas/TestDauphineCas.java
+++ b/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/cas/TestDauphineCas.java
@@ -2,6 +2,9 @@ package io.github.oliviercailloux.y2018.opendata.cas;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 
 /**
  * This DauphineCas implementation is used during integration tests
@@ -28,5 +31,13 @@ public class TestDauphineCas implements DauphineCas {
             return TEST_USERNAME;
         }
         throw new DauphineCasException();
+    }
+    
+    @Override
+    public HashSet<String> getRoles(String username) throws DauphineCasException {
+        if (!username.equals(TEST_USERNAME)) {
+            throw new DauphineCasException();
+        }
+        return new HashSet<>(Collections.singletonList(Roles.ADMIN));
     }
 }

--- a/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/cas/TestDauphineCas.java
+++ b/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/cas/TestDauphineCas.java
@@ -2,9 +2,6 @@ package io.github.oliviercailloux.y2018.opendata.cas;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 
 /**
  * This DauphineCas implementation is used during integration tests
@@ -13,31 +10,45 @@ import java.util.HashSet;
 @Default
 public class TestDauphineCas implements DauphineCas {
     
-    public final static String TEST_USERNAME = "user";
-    public final static String TEST_PASSWORD = "password";
-    public final static String TEST_TOKEN = "test-token";
+    public final static String ADMIN_USERNAME = "admin";
+    public final static String ADMIN_PASSWORD = "admin-password";
+    public final static String ADMIN_TOKEN = "admin-token";
+    
+    public final static String STUDENT_USERNAME = "user";
+    public final static String STUDENT_PASSWORD = "user-password";
+    public final static String STUDENT_TOKEN = "user-token";
+    
     
     @Override
     public String authenticate(Credentials credentials) throws DauphineCasException {
-        if (credentials.getUsername().equals(TEST_USERNAME) && credentials.getPassword().equals(TEST_PASSWORD)) {
-            return TEST_TOKEN;
+        if (credentials.getUsername().equals(ADMIN_USERNAME) && credentials.getPassword().equals(ADMIN_PASSWORD)) {
+            return ADMIN_TOKEN;
+        }
+        if (credentials.getUsername().equals(STUDENT_USERNAME) && credentials.getPassword().equals(STUDENT_PASSWORD)) {
+            return STUDENT_TOKEN;
         }
         throw new DauphineCasException();
     }
     
     @Override
     public String validateToken(String token) throws DauphineCasException {
-        if (token.equals(TEST_TOKEN)) {
-            return TEST_USERNAME;
+        if (token.equals(ADMIN_TOKEN)) {
+            return ADMIN_USERNAME;
+        }
+        if (token.equals(STUDENT_TOKEN)) {
+            return STUDENT_USERNAME;
         }
         throw new DauphineCasException();
     }
     
     @Override
-    public HashSet<String> getRoles(String username) throws DauphineCasException {
-        if (!username.equals(TEST_USERNAME)) {
-            throw new DauphineCasException();
+    public String[] getRoles(String username) throws DauphineCasException {
+        if (username.equals(ADMIN_USERNAME)) {
+            return new String[] {Roles.ADMIN};
         }
-        return new HashSet<>(Collections.singletonList(Roles.ADMIN));
+        if (username.equals(STUDENT_USERNAME)) {
+            return new String[] {Roles.STUDENT};
+        }
+        throw new DauphineCasException();
     }
 }

--- a/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/resource/AbstractResourceIT.java
+++ b/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/resource/AbstractResourceIT.java
@@ -100,7 +100,7 @@ public abstract class AbstractResourceIT<E extends io.github.oliviercailloux.y20
 
 	protected Builder sendJsonAcceptJsonUTF8English(final String path) {
 		final Builder builder = getResourceWebTarget(path).request();
-		sendToken(TestDauphineCas.TEST_TOKEN, builder);
+		sendToken(TestDauphineCas.ADMIN_TOKEN, builder);
 		sendJson(builder);
 		acceptEnglish(builder);
 		acceptJson(builder);

--- a/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/resource/AbstractResourceIT.java
+++ b/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/resource/AbstractResourceIT.java
@@ -20,6 +20,7 @@ import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import io.github.oliviercailloux.y2018.opendata.cas.DauphineCas;
 import io.github.oliviercailloux.y2018.opendata.cas.TestDauphineCas;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -98,14 +99,18 @@ public abstract class AbstractResourceIT<E extends io.github.oliviercailloux.y20
 		return getWebTarget().path(path);
 	}
 
-	protected Builder sendJsonAcceptJsonUTF8English(final String path) {
+	protected Builder sendJsonAcceptJsonUTF8English(final String path, final String token) {
 		final Builder builder = getResourceWebTarget(path).request();
-		sendToken(TestDauphineCas.ADMIN_TOKEN, builder);
+		sendToken(token, builder);
 		sendJson(builder);
 		acceptEnglish(builder);
 		acceptJson(builder);
 		acceptUTF8(builder);
 		return builder;
+	}
+	
+	protected Builder sendJsonAcceptJsonUTF8English(final String path) {
+		return sendJsonAcceptJsonUTF8English(path, TestDauphineCas.ADMIN_TOKEN);
 	}
 	
 	protected Builder sendJsonAcceptJsonUTF8English() {
@@ -156,7 +161,47 @@ public abstract class AbstractResourceIT<E extends io.github.oliviercailloux.y20
 		final Response response = sendJsonAcceptJsonUTF8English().post(Entity.json(persistedEntity));
 		assertStatusCodeIs(Status.CONFLICT.getStatusCode(), response);
 	}
-
+	
+	@Test
+	public void testGetIsAllowedToAll() {
+		assertStatusCodeIs(Status.OK.getStatusCode(), sendJsonAcceptJsonUTF8English("", TestDauphineCas.STUDENT_TOKEN).get());
+		assertStatusCodeIs(Status.OK.getStatusCode(), sendJsonAcceptJsonUTF8English("", TestDauphineCas.TEACHER_TOKEN).get());
+		assertStatusCodeIs(Status.OK.getStatusCode(), sendJsonAcceptJsonUTF8English("", TestDauphineCas.ADMIN_TOKEN).get());
+	}
+	
+	@Test
+	public void testGetIdIsAllowedToAll() {
+		assertStatusCodeIs(Status.NOT_FOUND.getStatusCode(), sendJsonAcceptJsonUTF8English("546545", TestDauphineCas.STUDENT_TOKEN).get());
+		assertStatusCodeIs(Status.NOT_FOUND.getStatusCode(), sendJsonAcceptJsonUTF8English("44564", TestDauphineCas.TEACHER_TOKEN).get());
+		assertStatusCodeIs(Status.NOT_FOUND.getStatusCode(), sendJsonAcceptJsonUTF8English("564564", TestDauphineCas.ADMIN_TOKEN).get());
+	}
+	
+	@Test
+	public void testPostIsReservedToAdmin() {
+		final E c = makeEntity();
+		assertStatusCodeIs(Status.FORBIDDEN.getStatusCode(), sendJsonAcceptJsonUTF8English("", TestDauphineCas.STUDENT_TOKEN).post(Entity.json(c)));
+		assertStatusCodeIs(Status.FORBIDDEN.getStatusCode(), sendJsonAcceptJsonUTF8English("", TestDauphineCas.TEACHER_TOKEN).post(Entity.json(c)));
+		assertStatusCodeIs(Status.CREATED.getStatusCode(), sendJsonAcceptJsonUTF8English("", TestDauphineCas.ADMIN_TOKEN).post(Entity.json(c)));
+	}
+	
+	@Test
+	public void testPutIsReservedToAdminAndTeacher() throws Exception {
+		final E c = makeEntity();
+		final E persistedEntity = getDao().persist(c);
+		assertStatusCodeIs(Status.FORBIDDEN.getStatusCode(), sendJsonAcceptJsonUTF8English("", TestDauphineCas.STUDENT_TOKEN).put(Entity.json(persistedEntity)));
+		assertStatusCodeIs(Status.NO_CONTENT.getStatusCode(), sendJsonAcceptJsonUTF8English("", TestDauphineCas.TEACHER_TOKEN).put(Entity.json(persistedEntity)));
+		assertStatusCodeIs(Status.NO_CONTENT.getStatusCode(), sendJsonAcceptJsonUTF8English("", TestDauphineCas.ADMIN_TOKEN).put(Entity.json(persistedEntity)));
+	}
+	
+	@Test
+	public void testDeleteIsReservedToAdmin() throws Exception {
+		final E c = makeEntity();
+		final E persistedEntity = getDao().persist(c);
+		assertStatusCodeIs(Status.FORBIDDEN.getStatusCode(), sendJsonAcceptJsonUTF8English(persistedEntity.getId().toString(), TestDauphineCas.STUDENT_TOKEN).delete());
+		assertStatusCodeIs(Status.FORBIDDEN.getStatusCode(), sendJsonAcceptJsonUTF8English(persistedEntity.getId().toString(), TestDauphineCas.TEACHER_TOKEN).delete());
+		assertStatusCodeIs(Status.NO_CONTENT.getStatusCode(), sendJsonAcceptJsonUTF8English(persistedEntity.getId().toString(), TestDauphineCas.ADMIN_TOKEN).delete());
+	}
+	
 	@Test
 	public void testPutMerge() throws Exception {
 		final E c = makeEntity();

--- a/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/resource/AuthenticationIT.java
+++ b/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/resource/AuthenticationIT.java
@@ -30,23 +30,23 @@ public class AuthenticationIT {
 	@Test
 	@RunAsClient
 	public void authenticate(@ArquillianResteasyResource("authentication") final WebTarget authenticationEndpoint) {
-		Response response = authenticationEndpoint.request().post(Entity.json(new Credentials(TestDauphineCas.TEST_USERNAME, TestDauphineCas.TEST_PASSWORD)));
+		Response response = authenticationEndpoint.request().post(Entity.json(new Credentials(TestDauphineCas.ADMIN_USERNAME, TestDauphineCas.ADMIN_PASSWORD)));
 		assertEquals(200, response.getStatus());
 		assertTrue(response.getMediaType().isCompatible(MediaType.TEXT_PLAIN_TYPE));
-		assertEquals(TestDauphineCas.TEST_TOKEN, response.readEntity(String.class));
+		assertEquals(TestDauphineCas.ADMIN_TOKEN, response.readEntity(String.class));
 	}
 	
 	@Test
 	@RunAsClient
 	public void wrongPassword(@ArquillianResteasyResource("authentication") final WebTarget authenticationEndpoint) {
-		Response response = authenticationEndpoint.request().post(Entity.json(new Credentials(TestDauphineCas.TEST_USERNAME, "wrong-password")));
+		Response response = authenticationEndpoint.request().post(Entity.json(new Credentials(TestDauphineCas.ADMIN_USERNAME, "wrong-password")));
 		assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
 	}
 	
 	@Test
 	@RunAsClient
 	public void wrongCredentialsFormat(@ArquillianResteasyResource("authentication") final WebTarget authenticationEndpoint) {
-		Response response = authenticationEndpoint.request().post(Entity.json(new Credentials(TestDauphineCas.TEST_USERNAME, null)));
+		Response response = authenticationEndpoint.request().post(Entity.json(new Credentials(TestDauphineCas.ADMIN_USERNAME, null)));
 		assertTrue(response.getMediaType().isCompatible(MediaType.APPLICATION_JSON_TYPE));
 		assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
 	}
@@ -55,7 +55,7 @@ public class AuthenticationIT {
 	@RunAsClient
 	public void secureAccess(@ArquillianResteasyResource("person") final WebTarget endpoint) {
 		Response response = endpoint.request()
-				.header(HttpHeaders.AUTHORIZATION, "Bearer " + TestDauphineCas.TEST_TOKEN)
+				.header(HttpHeaders.AUTHORIZATION, "Bearer " + TestDauphineCas.ADMIN_TOKEN)
 				.get();
 		assertTrue(response.getMediaType().isCompatible(MediaType.APPLICATION_JSON_TYPE));
 		assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
@@ -84,10 +84,10 @@ public class AuthenticationIT {
     @RunAsClient
     public void whoAmI(@ArquillianResteasyResource("authentication/whoami") final WebTarget endpoint) {
         Response response = endpoint.request()
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + TestDauphineCas.TEST_TOKEN).get();
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + TestDauphineCas.ADMIN_TOKEN).get();
         assertEquals(200, response.getStatus());
         assertTrue(response.getMediaType().isCompatible(MediaType.TEXT_PLAIN_TYPE));
-        assertEquals(TestDauphineCas.TEST_USERNAME, response.readEntity(String.class));
+        assertEquals(TestDauphineCas.ADMIN_USERNAME, response.readEntity(String.class));
     }
     
     @Test

--- a/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/resource/AuthorizationIT.java
+++ b/dauphine-open-data/src/test/java/io/github/oliviercailloux/y2018/opendata/resource/AuthorizationIT.java
@@ -1,0 +1,141 @@
+package io.github.oliviercailloux.y2018.opendata.resource;
+
+import io.github.oliviercailloux.y2018.opendata.ArquillianUtils;
+import io.github.oliviercailloux.y2018.opendata.cas.TestDauphineCas;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.extension.rest.client.ArquillianResteasyResource;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.*;
+
+@RunWith(Arquillian.class)
+public class AuthorizationIT {
+
+	@Deployment
+	public static WebArchive makeWar() {
+        return ArquillianUtils.makeWar("resource-it-war");
+	}
+	
+    @Test
+	@RunAsClient
+	public void permitAll(@ArquillianResteasyResource("test/authorization/permitAll") final WebTarget endpoint) {
+		Response response = endpoint.request().get();
+		assertEquals(200, response.getStatus());
+	}
+    
+    @Test
+    @RunAsClient
+    public void permitAllSecured(@ArquillianResteasyResource("test/authorization/permitAllSecured") final WebTarget endpoint) {
+        Response response = endpoint.request().header("authorization", "Bearer " + TestDauphineCas.ADMIN_TOKEN).get();
+        assertEquals(200, response.getStatus());
+    }
+    
+    @Test
+    @RunAsClient
+    public void permitAllSecuredFailure(@ArquillianResteasyResource("test/authorization/permitAllSecured") final WebTarget endpoint) {
+        Response response = endpoint.request().get();
+        assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
+    }
+    
+    @Test
+    @RunAsClient
+    public void denyAll(@ArquillianResteasyResource("test/authorization/denyAll") final WebTarget endpoint) {
+        Response response = endpoint.request().get();
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    }
+    
+    @Test
+    @RunAsClient
+    public void denyAllSecured(@ArquillianResteasyResource("test/authorization/denyAllSecured") final WebTarget endpoint) {
+        Response response = endpoint.request().header("authorization", "Bearer " + TestDauphineCas.ADMIN_TOKEN).get();
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    }
+    
+    @Test
+    @RunAsClient
+    public void denyAllSecuredFailure(@ArquillianResteasyResource("test/authorization/denyAllSecured") final WebTarget endpoint) {
+        Response response = endpoint.request().get();
+        assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
+    }
+    
+    
+    @Test
+    @RunAsClient
+    public void rolesAllowedAdminMissingSecured(@ArquillianResteasyResource("test/authorization/rolesAllowedAdmin") final WebTarget endpoint) {
+        Response response = endpoint.request().get();
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    }
+    
+    @Test
+    @RunAsClient
+    public void rolesAllowedAdminMissingSecuredWithToken(@ArquillianResteasyResource("test/authorization/rolesAllowedAdmin") final WebTarget endpoint) {
+        Response response = endpoint.request().header("authorization", "Bearer " + TestDauphineCas.ADMIN_TOKEN).get();
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    }
+    
+    @Test
+    @RunAsClient
+    public void rolesAllowedAdminSecured(@ArquillianResteasyResource("test/authorization/rolesAllowedAdminSecured") final WebTarget endpoint) {
+        Response response = endpoint.request().header("authorization", "Bearer " + TestDauphineCas.ADMIN_TOKEN).get();
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+    
+    @Test
+    @RunAsClient
+    public void rolesAllowedAdminSecuredNoToken(@ArquillianResteasyResource("test/authorization/rolesAllowedAdminSecured") final WebTarget endpoint) {
+        Response response = endpoint.request().get();
+        assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
+    }
+    
+    @Test
+    @RunAsClient
+    public void rolesAllowedAdminSecuredWrongToken(@ArquillianResteasyResource("test/authorization/rolesAllowedAdminSecured") final WebTarget endpoint) {
+        Response response = endpoint.request().header("authorization", "Bearer " + TestDauphineCas.ADMIN_TOKEN + "qsdqs").get();
+        assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
+    }
+    
+    @Test
+    @RunAsClient
+    public void rolesAllowedAdminSecuredNotAllowed(@ArquillianResteasyResource("test/authorization/rolesAllowedAdminSecured") final WebTarget endpoint) {
+        Response response = endpoint.request().header("authorization", "Bearer " + TestDauphineCas.STUDENT_TOKEN).get();
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    }
+    
+    @Test
+    @RunAsClient
+    public void rolesAllowedAdminAndStudentSecured(@ArquillianResteasyResource("test/authorization/rolesAllowedAdminAndStudentSecured") final WebTarget endpoint) {
+        Response response = endpoint.request().header("authorization", "Bearer " + TestDauphineCas.STUDENT_TOKEN).get();
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        Response response2 = endpoint.request().header("authorization", "Bearer " + TestDauphineCas.ADMIN_TOKEN).get();
+        assertEquals(Response.Status.OK.getStatusCode(), response2.getStatus());
+    }
+    
+    @Test
+    @RunAsClient
+    public void denyAllOverRoleAllowedAdminSecured(@ArquillianResteasyResource("test/authorization/denyAllOverRoleAllowedAdminSecured") final WebTarget endpoint) {
+        Response response = endpoint.request().header("authorization", "Bearer " + TestDauphineCas.ADMIN_TOKEN).get();
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    }
+    
+    @Test
+    @RunAsClient
+    public void roleAllowedAdminOverPermitAllSecured(@ArquillianResteasyResource("test/authorization/roleAllowedAdminOverPermitAllSecured") final WebTarget endpoint) {
+        Response response = endpoint.request().header("authorization", "Bearer " + TestDauphineCas.ADMIN_TOKEN).get();
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+    
+    @Test
+    @RunAsClient
+    public void roleAllowedAdminOverPermitAllSecuredFailure(@ArquillianResteasyResource("test/authorization/roleAllowedAdminOverPermitAllSecured") final WebTarget endpoint) {
+        Response response = endpoint.request().header("authorization", "Bearer " + TestDauphineCas.STUDENT_TOKEN).get();
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    }
+    
+}

--- a/doc/autorisation.adoc
+++ b/doc/autorisation.adoc
@@ -1,0 +1,93 @@
+= Autorisation
+
+Ce document explique le fonctionnement du mécanisme de contrôle d'accès qui a été mis en place dans ce projet.
+
+== Interaction avec le CAS de Dauphine
+
+Il est supposé que le projet évolue pour s'interconnecter avec le CAS de Dauphine. Le système de contrôle d'accès
+a donc été pensé pour faciliter cette intégration future.
+
+== Description du système de droits
+
+La gestion des droits se fait via la notion de "rôle". Un utilisateur possède une liste de rôles qui peut évoluer avec le temps.
+Ces rôles sont de simples chaînes de caractères. On peut demander au CAS de nous donner la liste des rôles associés à un
+utilisateur authentifié.
+
+Dans notre application nous allons ensuite déterminer des règles du type : "quel rôle peut accéder à quelle ressource".
+
+Pour l'instant, ces règles sont très simple. On peut restreindre l'accès d'une certaine route à un ensemble
+de rôles, et c'est tout.
+
+== Axe d'amélioration
+
+Les évolutions naturelles de ce système de droits serait :
+
+* autoriser l'accès à certaines route en fonction d'attribut présent dans les paramètres et le contexte de la requête
+** exemple : l'utilisateur toto a accès à la route `GET /person/toto`, et pas `GET /person/tata`.
+* autoriser l'accès à certaines lignes dans une table en fonction de l'utilisateur
+** exemple: lorsque l'utilisateur toto accède à la route `GET /course`, il reçoit uniquement la liste des cours auxquels il est inscrit.
+
+== Implementation JAVA
+
+=== Proxy DauphineCAS
+
+Le proxy DauphineCAS définit une méthode `getRoles(username) -> [roles]`. Cette méthode interroge le CAS et retourne
+la liste des rôles associés à un utilisateur.
+
+=== Annotations
+
+Le standard JAVA définit 3 annotations à positionner au dessus des méthodes ou des classes resources JAX-RS:
+
+* `@DenyAll`
+* `@PermitAll`
+* `@RolesAllowed({role1, role2,...})`
+
+
+=== Provider AuthenticationFilter
+
+Le provider `AuthenticationFilter`, déjà documenté dans `link:/doc/authentication.adoc[authentication.adoc], récupère
+les rôles associés à l'utlisateur (via le CAS) et les enregistre dans le `SecurityContext` de la requête.
+
+=== Provider AuthorizationFilter
+
+Le provider `AuthorizationFilter` intercepte les requêtes juste après `AuthenticationFilter`. Il est en charge de rejeter
+ou de laisser passer les requêtes en fonction des annotations et des rôles de l'utilisateur.
+
+Il procède de la façon suivante :
+
+1. Collecte des annotations sur la méthode resource jax-rs en utilisant la reflection
+2. Si elle possède l'annotation @DenyAll, la requête est rejetée
+3. Si elle possède l'annotation @RolesAllowed :
+  .. Récupération du `SecurityContext` de la requête
+  .. Si le client n'est pas authentifié, rejet de la requête
+  .. Si le l'utilisateur possède un des rôles listé dans l'annotation, la requête est acceptée
+  .. Sinon la requête est rejetée
+4. Si elle possède l'annotation @PermitAll, la requête est acceptée.
+5. Collecte des annotations sur la classe resource jax-rs en utilisant la reflection
+6. Répétition des étape 2,3 et 4 pour ces annotations.
+
+NOTE: la reflection se fait en injectant le `ResourceInfo`.
+
+NOTE: l'annotation @Priority sur `AuthorizationFilter` permet de s'assurer que le filtre est exécuté après l'authentification.
+
+=== Test d'integration
+
+Une séquence de tests d'intégration Arquillian est fournie (voir `AuthorizationIT`).
+
+Pour les besoins des tests, nous avons créé `AuthorizationResource` : une resource jax-rs utilisée pour tester les
+différentes combinaisons d'annotations.
+
+== Politique d'accès
+
+Pour les besoin de la demonstration, nous avons crée 3 rôles :
+
+* STUDENT
+* ADMIN
+* TEACHER
+
+
+Les étudiants peuvent lire et lister les resources. (GET et GET {id})
+
+Les professeurs peuvent en plus modifier des resources existantes (POST)
+
+Les admins peuvent en plus créer et supprimer des resources. (POST et DELETE)

--- a/doc/autorisation.adoc
+++ b/doc/autorisation.adoc
@@ -22,7 +22,7 @@ de rôles, et c'est tout.
 
 Les évolutions naturelles de ce système de droits serait :
 
-* autoriser l'accès à certaines route en fonction d'attribut présent dans les paramètres et le contexte de la requête
+* autoriser l'accès à certaines route en fonction d'attributs présents dans les paramètres et le contexte de la requête
 ** exemple : l'utilisateur toto a accès à la route `GET /person/toto`, et pas `GET /person/tata`.
 * autoriser l'accès à certaines lignes dans une table en fonction de l'utilisateur
 ** exemple: lorsque l'utilisateur toto accède à la route `GET /course`, il reçoit uniquement la liste des cours auxquels il est inscrit.
@@ -45,7 +45,7 @@ Le standard JAVA définit 3 annotations à positionner au dessus des méthodes o
 
 === Provider AuthenticationFilter
 
-Le provider `AuthenticationFilter`, déjà documenté dans `link:/doc/authentication.adoc[authentication.adoc], récupère
+Le provider `AuthenticationFilter`, déjà documenté dans link:/doc/authentication.adoc[authentication.adoc], récupère
 les rôles associés à l'utlisateur (via le CAS) et les enregistre dans le `SecurityContext` de la requête.
 
 === Provider AuthorizationFilter
@@ -60,26 +60,26 @@ Il procède de la façon suivante :
 3. Si elle possède l'annotation @RolesAllowed :
   .. Récupération du `SecurityContext` de la requête
   .. Si le client n'est pas authentifié, rejet de la requête
-  .. Si le l'utilisateur possède un des rôles listé dans l'annotation, la requête est acceptée
+  .. Si le l'utilisateur possède un des rôles listés dans l'annotation, la requête est acceptée
   .. Sinon la requête est rejetée
 4. Si elle possède l'annotation @PermitAll, la requête est acceptée.
 5. Collecte des annotations sur la classe resource jax-rs en utilisant la reflection
-6. Répétition des étape 2,3 et 4 pour ces annotations.
+6. Répétition des étapes 2,3 et 4 pour ces annotations.
 
 NOTE: la reflection se fait en injectant le `ResourceInfo`.
 
-NOTE: l'annotation @Priority sur `AuthorizationFilter` permet de s'assurer que le filtre est exécuté après l'authentification.
+NOTE: l'annotation @Priority sur `AuthorizationFilter` permet de s'assurer que le filtre est exécuté après le filtre d'authentification.
 
 === Test d'integration
 
 Une séquence de tests d'intégration Arquillian est fournie (voir `AuthorizationIT`).
 
-Pour les besoins des tests, nous avons créé `AuthorizationResource` : une resource jax-rs utilisée pour tester les
+Pour les besoins des tests, nous avons crée `AuthorizationResource` : une resource jax-rs utilisée pour tester les
 différentes combinaisons d'annotations.
 
 == Politique d'accès
 
-Pour les besoin de la demonstration, nous avons crée 3 rôles :
+Pour les besoins de la demonstration, nous avons crée 3 rôles :
 
 * STUDENT
 * ADMIN


### PR DESCRIPTION
Cette PR ajoute le contrôle d'accès aux routes basé sur des rôles qui sont récupérés depuis le CAS dauphine, elle dépend de la PR #25 : authentification. 

Choix d'implémentation :
* le proxy `DauphineCas` est intérogé pour obtenir la liste des roles associés à un utilisateur
* ces rôles sont ajoutés dans le `SecurityContext` de la requête par le provider `AuthenticationFilter`
* les annotations standards `@PermitAll`, `@DenyAll` et `@RolesAllowed` sont utilisés sur les ressources jax-rs
* un provider `AuthorizationFilter` autorise ou rejette les requêtes en fonction des annotations et des rôles du client
* beaucoup de tests d'intégration et unitaire ont été ajoutés pour valider le mécanisme
* Le `FakeDauphineCas` a été enrichi avec une fausse base d'utilisateurs et de rôles et un faux générateur de token.

Notes:
* les rôles ne sont pas hiérarchiques, ils s'apparentent plutôt à des privilèges.
* les rôles sont de simple chaînes de caractère.
* Pour le moment nous utilisons 3 rôles : student, teacher et admin. 

Todo:

- [x] Documentation
